### PR TITLE
CIまわりの改善

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
             - v1-dependencies-
       - run:
           name: install dependencies
-          command: bundle install --jobs=4 --retry=3 --path ./vendor/bundle
+          command: bundle install --jobs=4 --clean --path ./vendor/bundle
       - save_cache:
           paths:
             - ./vendor/bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,22 +1,23 @@
-version: 2
+version: 2.1
 
-default: &default
-  # specify the version you desire here
+web: &web
   - image: circleci/ruby:2.7.0-node-browsers
     environment:
       RAILS_ENV: test
       PGHOST: 127.0.0.1
       DATABASE_USER: circleci
       DATABASE_PASSWORD: password
+db: &db
+  - image: circleci/postgres
+    environment:
+      POSTGRES_USER: circleci
+      POSTGRES_PASSWORD: password
 
 jobs:
   build:
     docker:
-      - <<: *default
-      - image: circleci/postgres
-        environment:
-          POSTGRES_USER: circleci
-          POSTGRES_PASSWORD: password
+      - <<: *web
+      - <<: *db
     steps:
       - checkout
       - persist_to_workspace:
@@ -25,7 +26,7 @@ jobs:
             - .
   node_build:
     docker:
-      - <<: *default
+      - <<: *web
     steps:
       - attach_workspace:
           at: .
@@ -45,11 +46,8 @@ jobs:
           command: yarn lint
   ruby_build:
     docker:
-      - <<: *default
-      - image: circleci/postgres
-        environment:
-          POSTGRES_USER: circleci
-          POSTGRES_PASSWORD: password
+      - <<: *web
+      - <<: *db
     steps:
       - attach_workspace:
           at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,10 @@ executors:
       - <<: *db
 
 commands:
+  attach_current:
+    steps:
+      - attach_workspace:
+          at: .
   cache_node_deps:
     steps:
       - save_cache:
@@ -74,13 +78,18 @@ jobs:
     executor:
       name: web
     steps:
-      - attach_workspace:
-          at: .
+      - attach_current
       - restore_node_deps
       - run:
           name: install dependencies
           command: yarn install
       - cache_node_deps
+  node_lint:
+    executor:
+      name: web
+    steps:
+      - attach_current
+      - restore_node_deps
       - run:
           name: run code analyze
           command: yarn lint
@@ -88,8 +97,7 @@ jobs:
     executor:
       name: web-db
     steps:
-      - attach_workspace:
-          at: .
+      - attach_current
       - configure_bundler
       - restore_ruby_deps
       - run:
@@ -123,3 +131,6 @@ workflows:
       - node_build:
           requires:
             - build
+      - node_lint:
+          requires:
+            - node_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,44 @@ executors:
       - <<: *web
       - <<: *db
 
+commands:
+  cache_node_deps:
+    steps:
+      - save_cache:
+          name: Cache node dependencies
+          paths:
+            - ./node_modules
+          key: v1-node-dependencies-{{ checksum "yarn.lock" }}
+  restore_node_deps:
+    steps:
+      - restore_cache:
+          name: Restore node dependencies
+          keys:
+            - v1-node-dependencies-{{ checksum "yarn.lock" }}
+            - v1-dependencies-
+  configure_bundler:
+    steps:
+      - run:
+          name: Configure Bundler
+          command: |
+            echo 'export BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")' >> $BASH_ENV
+            source $BASH_ENV
+            gem install bundler -v $BUNDLER_VERSION
+  cache_ruby_deps:
+    steps:
+      - save_cache:
+          name: Cache ruby dependencies
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+  restore_ruby_deps:
+    steps:
+      - restore_cache:
+          name: Restore node dependencies
+          keys:
+            - v1-dependencies-{{ checksum "Gemfile.lock" }}
+            - v1-dependencies-
+
 jobs:
   build:
     executor:
@@ -38,17 +76,11 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - restore_cache:
-          keys:
-          - v1-node-dependencies-{{ checksum "yarn.lock" }}
-          - v1-dependencies-
+      - restore_node_deps
       - run:
           name: install dependencies
           command: yarn install
-      - save_cache:
-          paths:
-            - ./node_modules
-          key: v1-node-dependencies-{{ checksum "yarn.lock" }}
+      - cache_node_deps
       - run:
           name: run code analyze
           command: yarn lint
@@ -58,23 +90,12 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - run:
-          name: Configure Bundler
-          command: |
-            echo 'export BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")' >> $BASH_ENV
-            source $BASH_ENV
-            gem install bundler -v $BUNDLER_VERSION
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "Gemfile.lock" }}
-            - v1-dependencies-
+      - configure_bundler
+      - restore_ruby_deps
       - run:
           name: install dependencies
           command: bundle install --jobs=4 --clean --path ./vendor/bundle
-      - save_cache:
-          paths:
-            - ./vendor/bundle
-          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+      - cache_ruby_deps
       - run:
           name: run rubocop
           command: bundle exec rubocop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,11 +13,19 @@ db: &db
       POSTGRES_USER: circleci
       POSTGRES_PASSWORD: password
 
-jobs:
-  build:
+executors:
+  web:
+    docker:
+      - <<: *web
+  web-db:
     docker:
       - <<: *web
       - <<: *db
+
+jobs:
+  build:
+    executor:
+      name: web-db
     steps:
       - checkout
       - persist_to_workspace:
@@ -25,8 +33,8 @@ jobs:
           paths:
             - .
   node_build:
-    docker:
-      - <<: *web
+    executor:
+      name: web
     steps:
       - attach_workspace:
           at: .
@@ -45,9 +53,8 @@ jobs:
           name: run code analyze
           command: yarn lint
   ruby_build:
-    docker:
-      - <<: *web
-      - <<: *db
+    executor:
+      name: web-db
     steps:
       - attach_workspace:
           at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,11 @@ commands:
     steps:
       - attach_workspace:
           at: .
+  install_node_deps:
+    steps:
+      - run:
+          name: install node dependencies
+          command: yarn install
   cache_node_deps:
     steps:
       - save_cache:
@@ -85,9 +90,7 @@ jobs:
     steps:
       - attach_current
       - restore_node_deps
-      - run:
-          name: install dependencies
-          command: yarn install
+      - install_node_deps
       - cache_node_deps
   node_lint:
     executor:
@@ -95,6 +98,7 @@ jobs:
     steps:
       - attach_current
       - restore_node_deps
+      - install_node_deps
       - run:
           name: run code analyze
           command: yarn lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ commands:
 jobs:
   build:
     executor:
-      name: web-db
+      name: web
     steps:
       - checkout
       - persist_to_workspace:
@@ -100,7 +100,7 @@ jobs:
           command: yarn lint
   ruby_build:
     executor:
-      name: web-db
+      name: web
     steps:
       - attach_current
       - configure_bundler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,11 @@ commands:
             echo 'export BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")' >> $BASH_ENV
             source $BASH_ENV
             gem install bundler -v $BUNDLER_VERSION
+  install_ruby_deps:
+    steps:
+      - run:
+          name: install dependencies
+          command: bundle install --jobs=4 --clean --path ./vendor/bundle
   cache_ruby_deps:
     steps:
       - save_cache:
@@ -59,7 +64,7 @@ commands:
   restore_ruby_deps:
     steps:
       - restore_cache:
-          name: Restore node dependencies
+          name: Restore ruby dependencies
           keys:
             - v1-dependencies-{{ checksum "Gemfile.lock" }}
             - v1-dependencies-
@@ -100,16 +105,30 @@ jobs:
       - attach_current
       - configure_bundler
       - restore_ruby_deps
-      - run:
-          name: install dependencies
-          command: bundle install --jobs=4 --clean --path ./vendor/bundle
+      - install_ruby_deps
       - cache_ruby_deps
+  ruby_lint:
+    executor:
+      name: web
+    steps:
+      - attach_current
+      - restore_ruby_deps
+      - configure_bundler
+      - install_ruby_deps
       - run:
           name: run rubocop
           command: bundle exec rubocop
       - run:
           name: run brakeman
           command: bundle exec brakeman
+  ruby_test:
+    executor:
+      name: web-db
+    steps:
+      - attach_current
+      - restore_ruby_deps
+      - configure_bundler
+      - install_ruby_deps
       - run:
           name: run migration
           command: |
@@ -117,9 +136,7 @@ jobs:
             bundle exec rake db:schema:load
       - run:
           name: run tests
-          command: |
-            TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
-            bundle exec rspec $TEST_FILES
+          command: bundle exec rspec spec/
 workflows:
   version: 2
   build:
@@ -128,6 +145,12 @@ workflows:
       - ruby_build:
           requires:
             - build
+      - ruby_lint:
+          requires:
+            - ruby_build
+      - ruby_test:
+          requires:
+            - ruby_build
       - node_build:
           requires:
             - build


### PR DESCRIPTION
# circleci version 2.1の新機能を使ってリファクタリング
circleciのconfigのvarsionを2.1にアップデートして`executer`及び`commands`を使ってリファクタリングした。

* executor
  - webだけ、web + dbのexecutorを用意して、それを使い分けるように

* commands
  - 複数のjobで使うものはcommandsに切り出して流用できるように

ref:
* executors: https://circleci.com/docs/ja/2.0/configuration-reference/#executorsversion21-%E3%81%8C%E5%BF%85%E9%A0%88
* commands: https://circleci.com/docs/ja/2.0/configuration-reference/#commandsversion21-%E3%81%8C%E5%BF%85%E9%A0%88

## workflowの改善
先程の`executer`と`commands`
下記のようなworkflow構成に変更してlintとtestが並列に実行されるようにし、失敗した箇所もわかりやすくした。

![image](https://user-images.githubusercontent.com/17684091/86013061-b208d380-ba59-11ea-8162-186e85643184.png)

※bundlerのinstallのcacheの方法がわからなかったので、そこはオーバーヘッドになりそうだが、前述のメリットの方が大きいと判断した。