### PR TITLE
FeedCardCollectionのリファクタリング

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 config
+babel.config.js
 app/assets/javascripts/cable.js

--- a/app/javascript/components/FeedCardCollection.vue
+++ b/app/javascript/components/FeedCardCollection.vue
@@ -21,7 +21,6 @@ import { Feed, Entry, FeedTag, FeedsResponse } from "@js/types/types.d.ts";
 import FeedCard from "@js/components/FeedCard.vue";
 import PageLoader from "@js/components/PageLoader.vue";
 import InfiniteLoading from "vue-infinite-loading";
-import axios, { AxiosResponse } from "axios";
 import DeviceChecker from "@js/common/DeviceChecker";
 import { getFeeds } from "@js/services/FeedService";
 
@@ -65,12 +64,8 @@ export default Vue.extend({
   created: async function() {
     const checker = new DeviceChecker(navigator.userAgent);
     // MEMO: 初回表示時にデータ取得するため実行
-    if (!checker.isMobile()) {
-      this.infiniteHandler();
-    }
-    this.$nextTick(function() {
-      this.isLoading = false;
-    });
+    if (!checker.isMobile()) await this.infiniteHandler();
+    this.isLoading = false;
   },
   methods: {
     feedLastEntry: function(feed: Feed): Entry {

--- a/app/javascript/components/FeedCardCollection.vue
+++ b/app/javascript/components/FeedCardCollection.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="entries is-multiline columns">
-    <page-loader :init_is_loading="isLoading" />
     <div
       v-for="feed in feeds"
       :key="feed.id"
@@ -12,29 +11,22 @@
         :tags="feedTags(feed)"
       />
     </div>
-    <infinite-loading @infinite="infiniteHandler" />
   </div>
 </template>
 <script lang="ts">
 import Vue, { PropType } from "vue";
-import { Feed, Entry, FeedTag, FeedsResponse } from "@js/types/types.d.ts";
+import { Feed, Entry, FeedTag } from "@js/types/types.d.ts";
 import FeedCard from "@js/components/FeedCard.vue";
-import PageLoader from "@js/components/PageLoader.vue";
-import InfiniteLoading from "vue-infinite-loading";
-import DeviceChecker from "@js/common/DeviceChecker";
-import { getFeeds } from "@js/services/FeedService";
 
 interface DataType {
-  page: number;
   feeds: Feed[];
   lastEntries: Entry[];
   tags: FeedTag[];
-  isLoading: boolean;
 }
 
 export default Vue.extend({
   name: "FeedCardCollection",
-  components: { FeedCard, PageLoader, InfiniteLoading },
+  components: { FeedCard },
   props: {
     initFeeds: {
       type: Array as PropType<Feed[]>,
@@ -54,18 +46,10 @@ export default Vue.extend({
   },
   data(): DataType {
     return {
-      page: 1,
       feeds: this.initFeeds,
       lastEntries: this.initLastEntries,
       tags: this.initTags,
-      isLoading: true
     };
-  },
-  created: async function() {
-    const checker = new DeviceChecker(navigator.userAgent);
-    // MEMO: 初回表示時にデータ取得するため実行
-    if (!checker.isMobile()) await this.infiniteHandler();
-    this.isLoading = false;
   },
   methods: {
     feedLastEntry: function(feed: Feed): Entry {
@@ -73,21 +57,6 @@ export default Vue.extend({
     },
     feedTags: function(feed: Feed): FeedTag {
       return this.tags.filter(tag => tag.feed_id === feed.id);
-    },
-    updateFeedList: function(feeds: Feed[], lastEntries: Entry[], tags: FeedTag[]): void {
-      this.feeds.push(...feeds);
-      this.lastEntries.push(...lastEntries);
-      this.tags.push(...tags);
-    },
-    infiniteHandler: async function ($state: any): Promise<void> {
-      const data: FeedsResponse = await getFeeds(location.search, { page: this.page });
-      if (data.feeds.length) {
-        this.page += 1;
-        this.updateFeedList(data.feeds, data.last_entries, data.tags);
-        if ($state) { $state.loaded(); }
-      } else {
-        if ($state) { $state.complete(); }
-      }
     }
   }
 });

--- a/app/javascript/components/containers/NewBoardContainer.vue
+++ b/app/javascript/components/containers/NewBoardContainer.vue
@@ -1,0 +1,99 @@
+<template>
+  <div
+    id="boards"
+    class="boards-new columns"
+  >
+    <selected-feed-collection />
+    <main class="column">
+      <article class="message">
+        <div class="message-header">
+          <p>Dogfeedsとは？</p>
+        </div>
+        <div class="message-body">
+          <strong>
+            RSSフィードをまとめたRssフィードを作ることができます。
+            作り方は簡単なので、ぜひ作ってみてください🐶
+          </strong>
+          <br>
+          1. フィードを選択する<br>
+          2. まとめたフィード(ボード)に名前をつける<br>
+          3. ボードを作って、共有するなり、Slackチャンネルに追加するなりする！<br>
+        </div>
+      </article>
+      <div class="level-left column is-12">
+        <search-form :init_keyword="searchWord" />
+      </div>
+      <feed-card-collection
+        :init-feeds="feeds"
+        :init-last-entries="lastEntries"
+        :init-tags="tags"
+      />
+      <infinite-loading
+        :distance="100"
+        @infinite="infiniteHandler"
+      />
+    </main>
+  </div>
+</template>
+<script lang="ts">
+import Vue from "vue";
+import FeedCardCollection from "@js/components/FeedCardCollection.vue";
+import SelectedFeedCollection from "@js/components/SelectedFeedCollection.vue";
+import SearchForm from "@js/components/SearchForm.vue";
+import InfiniteLoading from "vue-infinite-loading";
+import { getFeeds } from "@js/services/FeedService";
+import { Feed, Entry, FeedTag, FeedsResponse } from "@js/types/types.d.ts";
+
+interface DataType {
+  page: number;
+  feeds: Feed[];
+  lastEntries: Entry[];
+  tags: FeedTag[];
+  isInitLoading: boolean;
+  isInfiniteLoading: boolean;
+}
+
+export default Vue.extend({
+  name: "NewBoardContainer",
+  components: { FeedCardCollection, SelectedFeedCollection, SearchForm, InfiniteLoading },
+  props: {
+    searchWord: {
+      type: String,
+      default: "",
+      require: false,
+    }
+  },
+  data(): DataType {
+    return {
+      page: 1,
+      feeds: [],
+      lastEntries: [],
+      tags: [],
+      isLoading: false,
+    };
+  },
+  methods: {
+    updateFeedList: function(feeds: Feed[], lastEntries: Entry[], tags: FeedTag[]): void {
+      this.feeds.push(...feeds);
+      this.lastEntries.push(...lastEntries);
+      this.tags.push(...tags);
+    },
+    infiniteHandler: async function ($state: any): Promise<void> {
+      if(this.isLoading) return;
+
+      this.isLoading = true;
+      const data: FeedsResponse = await getFeeds(location.search, { page: this.page });
+      if (data.feeds.length) {
+        this.page += 1;
+        this.updateFeedList(data.feeds, data.last_entries, data.tags);
+        if ($state) { $state.loaded(); }
+      } else {
+        $state.complete();
+      }
+      this.isLoading = false;
+    }
+  }
+});
+</script>
+<style lang="scss">
+</style>

--- a/app/javascript/packs/boards/new.js
+++ b/app/javascript/packs/boards/new.js
@@ -1,7 +1,5 @@
 import Vue from "vue/dist/vue.esm";
-import FeedCardCollection from "../../components/FeedCardCollection";
-import SelectedFeedCollection from "../../components/SelectedFeedCollection";
-import SearchForm from "../../components/SearchForm";
+import NewBoardContainer from "@js/components/containers/NewBoardContainer.vue";
 import fontawesome from "@fortawesome/fontawesome";
 import { fas } from "@fortawesome/free-solid-svg-icons";
 import { fab } from "@fortawesome/free-brands-svg-icons";
@@ -9,10 +7,6 @@ import { far } from "@fortawesome/free-regular-svg-icons";
 fontawesome.library.add(fas, fab, far);
 
 new Vue({
-  el: "#boards",
-  components: {
-    FeedCardCollection,
-    SelectedFeedCollection,
-    SearchForm
-  },
+  el: "#vue-root",
+  components: { NewBoardContainer },
 });

--- a/app/javascript/services/FeedService.ts
+++ b/app/javascript/services/FeedService.ts
@@ -1,0 +1,9 @@
+import axios, { AxiosResponse } from "axios";
+import { FeedsResponse } from "@js/types/types.d.ts";
+
+const FEEDS_API_ENDPOINT = "/api/feeds";
+
+export async function getFeeds(query: "", params: object): Promise<FeedsResponse> {
+  const response: AxiosResponse = await axios.get(FEEDS_API_ENDPOINT + query, {params: params});
+  return response.data;
+}

--- a/app/views/boards/new.html.erb
+++ b/app/views/boards/new.html.erb
@@ -1,25 +1,4 @@
-<div class="boards-new columns" id="boards">
-  <selected-feed-collection></selected-feed-collection>
-  <main class="column">
-    <article class="message">
-      <div class="message-header">
-        <p>Dogfeedsとは？</p>
-      </div>
-      <div class="message-body">
-        <strong>
-          RSSフィードをまとめたRssフィードを作ることができます。
-          作り方は簡単なので、ぜひ作ってみてください🐶
-        </strong>
-        </br>
-        1. フィードを選択する</br>
-        2. まとめたフィード(ボード)に名前をつける</br>
-        3. ボードを作って、共有するなり、Slackチャンネルに追加するなりする！</br>
-      </div>
-    </article>
-    <div class="level-left column is-12">
-      <search-form init_keyword="<%= params.dig(:query, :keyword) %>" />
-    </div>
-    <feed-card-collection />
-  </main>
+<div id="vue-root">
+  <new-board-container search-word="<%= params.dig(:query, :keyword) %>" />
 </div>
 <%= javascript_pack_tag 'boards/new' %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,25 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+puts "=== START ==="
+
+puts "=== delete old data ==="
+ActiveRecord::Base.transaction {
+  Entry.delete_all
+  Feed.delete_all
+}
+
+puts "=== create feeds ==="
+FactoryBot.create_list(:feed, 10)
+
+puts "=== create entries ==="
+Feed.all.each do |feed|
+  sleep 1
+  ActiveRecord::Base.transaction { Feed::EntryCreater.new(feed).execute! }
+rescue => e
+  Rails.logger.error(e)
+  next
+end
+
+puts "=== FINISHED ==="

--- a/lib/tasks/entries_recreate.rake
+++ b/lib/tasks/entries_recreate.rake
@@ -2,6 +2,7 @@ namespace :entries do
   desc 'It is a task to re-acquire the latest articles related to all Feeds'
   task recreate: :environment do
     Feed.all.each do |feed|
+      sleep 1
       ActiveRecord::Base.transaction { Feed::EntryCreater.new(feed).execute! }
     rescue => e
       Rails.logger.error(e)

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "scripts": {
-    "lint": "eslint app/javascript/**/*",
-    "lint-fix": "eslint app/javascript/**/* --fix"
+    "lint": "eslint app/javascript/**/* --ext .vue,.js,.ts",
+    "lint-fix": "eslint app/javascript/**/* --ext .vue,.js,.ts --fix"
   }
 }

--- a/spec/factories/feeds.rb
+++ b/spec/factories/feeds.rb
@@ -12,7 +12,7 @@
 
 FactoryBot.define do
   factory :feed do
-    title { 'title' }
+    sequence(:title) { |n| "title_#{n}" }
     last_published_at { Time.current }
     endpoint { 'https://madogiwa0124.hatenablog.com/rss' }
   end


### PR DESCRIPTION
主に下記をリファクタリング

* リクエスト送信部分は、コンポーネントから切り離してservices配下でまとめて管理するようにした
  - リクエスト送信の具体的なロジックはcomponentsで扱う関心じゃないと考えたため
* リクエスト送信処理は、コンポーネントを分けてcontainer配下のコンポーネントで実行するようにした
  - どのコンポーネントがリクエストを投げているかわかりやすくするため
* Lodingは初回ロードを無限スクロールで分けて扱っているのがわかりにくかったので無限スクロールのローディングに一本化

またエントリの取得時にsleep入れてなかったので、1秒待つようにした ⚠️💦 