### PR TITLE
Rssの取得部分のMock方法を見直し

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,5 @@ end
 group :test do
   gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'
-  gem 'webmock'
   gem 'simplecov', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,8 +74,6 @@ GEM
       xpath (~> 3.2)
     childprocess (3.0.0)
     concurrent-ruby (1.1.6)
-    crack (0.4.3)
-      safe_yaml (~> 1.0.0)
     crass (1.0.6)
     diff-lcs (1.3)
     docile (1.3.2)
@@ -92,7 +90,6 @@ GEM
     ffi (1.11.3)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    hashdiff (1.0.1)
     i18n (1.8.4)
       concurrent-ruby (~> 1.0)
     listen (3.2.1)
@@ -194,7 +191,6 @@ GEM
       rubocop (>= 0.87.0)
     ruby-progressbar (1.10.1)
     rubyzip (2.3.0)
-    safe_yaml (1.0.5)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -216,10 +212,6 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
-    webmock (3.8.3)
-      addressable (>= 2.3.6)
-      crack (>= 0.3.2)
-      hashdiff (>= 0.4.0, < 2.0.0)
     webpacker (5.1.1)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
@@ -252,7 +244,6 @@ DEPENDENCIES
   selenium-webdriver
   simplecov
   spp
-  webmock
   webpacker
 
 RUBY VERSION

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -22,6 +22,8 @@ class Feed < ApplicationRecord
   has_many :feed_taggings, dependent: :destroy
   has_many :tags, through: :feed_taggings, class_name: 'FeedTag', source: :feed_tag
 
+  attribute :client_class, default: Feed::RssClient
+
   validates :title, presence: true
   validates :endpoint, presence: true, format: URI_REGEXP_PATTERN
 
@@ -43,7 +45,7 @@ class Feed < ApplicationRecord
   }
 
   def parsed_items
-    @parsed_items ||= Feed::RssClient.new(endpoint).parsed_items
+    @parsed_items ||= client_class.new(endpoint).parsed_items
   rescue RSS::NotWellFormedError => e
     logger.error(e)
     invalid_rss_format

--- a/app/models/feed/rss_client.rb
+++ b/app/models/feed/rss_client.rb
@@ -3,16 +3,16 @@ class Feed::RssClient
     @endpoint = endpoint
   end
 
-  def rss_source
-    @rss_source ||= Net::HTTP.get(URI.parse(endpoint))
+  def resource
+    @resource ||= Net::HTTP.get(URI.parse(endpoint))
   end
 
   attr_reader :endpoint
 
   def parsed_rss!
-    RSS::Parser.parse(rss_source)
+    RSS::Parser.parse(resource)
   rescue RSS::InvalidRSSError
-    RSS::Parser.parse(rss_source, false)
+    RSS::Parser.parse(resource, false)
   end
 
   def parsed_items

--- a/spec/helpers/rss_mock_helper.rb
+++ b/spec/helpers/rss_mock_helper.rb
@@ -1,10 +1,6 @@
 module RssMockHelper
-  def rss_mock_enable(endpoint:, body:, status: 200)
-    WebMock.enable!
-    WebMock.stub_request(:get, endpoint).to_return(
-      body: body,
-      status: status,
-      headers: { 'Content-Type' => 'application/rss+xml' }
-    )
+  def rss_mock_enable(resource:)
+    # NOTE: Feedのclientをattribute定義したので、それを差し替えるようにしても良いかもしれない。
+    allow_any_instance_of(Feed::RssClient).to receive(:resource).and_return(resource)
   end
 end

--- a/spec/models/feed_spec.rb
+++ b/spec/models/feed_spec.rb
@@ -98,31 +98,30 @@ RSpec.describe Feed, type: :model do
 
   describe '#parsed_items' do
     include RssMockHelper
+    let(:feed) { build(:feed) }
 
-    before do
-      valid_body = File.read(Rails.root.join('spec/sample/rss.xml'))
-      rss_mock_enable(endpoint: 'https://example.com/rss', body: valid_body)
-      invald_body = '<html invald format</html>'
-      rss_mock_enable(endpoint: 'https://example.com/', body: invald_body)
-    end
-
-    let(:feed) { build(:feed, endpoint: endpoint) }
-
-    context '正しいendpointの場合' do
-      let(:endpoint) { 'https://example.com/rss' }
+    context '正しいRSS形式の場合' do
+      before do
+        valid_body = File.read(Rails.root.join('spec/sample/rss.xml'))
+        rss_mock_enable(resource: valid_body)
+      end
 
       it 'Parseされた記事の一覧が取得出来ること' do
-        expect(feed.parsed_items.length).to be_positive
+        expect(feed.parsed_items.length).to eq 2
+        expect(feed.parsed_items.map(&:title)).to eq ['title 1', 'title 2']
       end
     end
 
-    context '不正なendpointの場合' do
-      let(:endpoint) { 'https://example.com' }
+    context '不正なRSS形式の場合' do
       let(:mssages) { 'rssフィードの形式が不正です。エンドポイントをご確認ください。' }
 
-      before { feed.parsed_items }
+      before do
+        invald_body = '<html invald format</html>'
+        rss_mock_enable(resource: invald_body)
+      end
 
-      it 'errorが発生すること' do
+      it 'エラーメッセージが設定されること' do
+        feed.parsed_items
         expect(feed.errors.messages[:base]).to include(mssages)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,9 @@
-require 'webmock'
 require 'simplecov'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
-  config.mock_with :rspec do |mocks|
-    mocks.verify_partial_doubles = true
-  end
-  WebMock.allow_net_connect!
   config.shared_context_metadata_behavior = :apply_to_host_groups
 end
 

--- a/spec/system/feeds/new_spec.rb
+++ b/spec/system/feeds/new_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'フィード作成画面', type: :system, js: true do
 
     before do
       valid_body = File.read(Rails.root.join('spec/sample/rss.xml'))
-      rss_mock_enable(endpoint: 'https://example.com/rss', body: valid_body)
+      rss_mock_enable(resource: valid_body)
       visit new_feed_path
     end
 


### PR DESCRIPTION
ちょっとお行儀悪いけど、
Webmockではなくてallow_any_instance_ofを使うようにしたほうがスッキリかけそうだったので、
そんな感じに修正した。

※一応Feedにattributesでclientをもたせたので、今後いまいちになってきたら差し替えるような方針で修正も検討