### PR TITLE
boardに表示されるFeedタイトルが多すぎるとdesignが崩壊するので制限した

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -11,6 +11,8 @@
 class Board < ApplicationRecord
   require 'rss'
 
+  MAX_DISPLAY_FEED = 5
+
   has_many :board_feeds, dependent: :destroy
   has_many :feeds, through: :board_feeds
   has_many :entries, through: :feeds
@@ -21,7 +23,10 @@ class Board < ApplicationRecord
   end
 
   def description
-    "「#{feeds.map(&:title).join('、')}」をまとめたRSSフィードです。"
+    # NOTE: 表示件数より多くのFeedを持つことをチェックするために+1した件数を取得する
+    display_feeds = feeds.first(MAX_DISPLAY_FEED + 1)
+    omission = display_feeds.length > MAX_DISPLAY_FEED ? ' ...' : ''
+    "「#{display_feeds.first(MAX_DISPLAY_FEED).map(&:title).join('、')}#{omission}」をまとめたRSSフィードです。"
   end
 
   def self.create_with_board_feeds!(title:, feeds:)

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -39,6 +39,21 @@ RSpec.describe Board, type: :model do
     it 'フィードのタイトルを結合した文言が取得出来ること' do
       expect(board.description).to eq description
     end
+
+    context '紐づくFeedの数が5件を超える場合' do
+      let(:description) { '「タイトル1、タイトル2、タイトル3、タイトル4、タイトル5 ...」をまとめたRSSフィードです。' }
+
+      before do
+        board.board_feeds.create(feed: create(:feed, title: 'タイトル3'))
+        board.board_feeds.create(feed: create(:feed, title: 'タイトル4'))
+        board.board_feeds.create(feed: create(:feed, title: 'タイトル5'))
+        board.board_feeds.create(feed: create(:feed, title: 'タイトル6'))
+      end
+
+      it '6件目は省略されてフィードのタイトルを結合した文言が取得出来ること' do
+        expect(board.description).to eq description
+      end
+    end
   end
 
   describe '.create_with_board_feeds!' do
@@ -50,7 +65,7 @@ RSpec.describe Board, type: :model do
       it 'デフォルトのタイトルでboadとfeedが作成されること' do
         board = described_class.create_with_board_feeds!(args)
         expect(board.title).to eq '無題のボード'
-        expect(board.feeds).to eq feeds
+        expect(board.feeds).to match_array feeds
       end
     end
 
@@ -60,7 +75,7 @@ RSpec.describe Board, type: :model do
       it '指定したタイトルでboadとfeedが作成されること' do
         board = described_class.create_with_board_feeds!(args)
         expect(board.title).to eq 'title'
-        expect(board.feeds).to eq feeds
+        expect(board.feeds).to match_array feeds
       end
     end
   end
@@ -71,7 +86,7 @@ RSpec.describe Board, type: :model do
 
     it '引数で渡されたidを持つfeedsに書き換わること' do
       board.recreate_board_feeds!(feeds.map(&:id))
-      expect(board.feeds).to eq feeds
+      expect(board.feeds).to match_array feeds
     end
   end
 end

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Board, type: :model do
       let(:args) { { feeds: feeds, title: nil } }
 
       it 'デフォルトのタイトルでboadとfeedが作成されること' do
-        board = described_class.create_with_board_feeds!(args)
+        board = described_class.create_with_board_feeds!(**args)
         expect(board.title).to eq '無題のボード'
         expect(board.feeds).to match_array feeds
       end
@@ -73,7 +73,7 @@ RSpec.describe Board, type: :model do
       let(:args) { { feeds: feeds, title: 'title' } }
 
       it '指定したタイトルでboadとfeedが作成されること' do
-        board = described_class.create_with_board_feeds!(args)
+        board = described_class.create_with_board_feeds!(**args)
         expect(board.title).to eq 'title'
         expect(board.feeds).to match_array feeds
       end


### PR DESCRIPTION
boardに表示されるFeedタイトルが多すぎるとdesignが崩壊するので制限した :cry:
あとはwarnningが出てるところをfixしてみた。