### PR TITLE
開発環境ではRubyの警告を表示するようにした

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       DATABASE_PASSWORD: password
       DATABASE_PORT: 5432
       DATABASE_HOST: db
+      RUBYOPT: '-w'
 volumes:
   node_modules:
     driver: 'local'


### PR DESCRIPTION
ライブラリの警告は結構出てしまうものの`-w`でコンパイル時の警告を表示するようにしてみた。

https://docs.ruby-lang.org/ja/latest/doc/spec=2frubycmd.html