### PR TITLE
Revert "今後複数DBに対応しやすいように複数DBを有効にして同一のDBを見るようにしておく"

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,4 +1,3 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
-  connects_to database: { writing: :primary, reading: :replica }
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,8 +32,5 @@ module Dogfeeds
       g.fixture_replacement :factory_bot, dir: 'spec/factories'
     end
     config.action_view.field_error_proc = Proc.new { |html_tag, instance| %Q(#{html_tag}).html_safe }
-    config.active_record.database_selector = { delay: 2.seconds }
-    config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
-    config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,36 +2,22 @@ default: &default
   adapter: postgresql
   encoding: unicode
 
-database_config: &database_config
+development:
   <<: *default
+  database: dogfeeds_development
   host: <%= ENV.fetch('DATABASE_HOST') { 'localhost' } %>
   port: <%= ENV.fetch('DATABASE_PORT') { '5432' } %>
   username: <%= ENV.fetch('DATABASE_USER') { 'postgres' } %>
   password: <%= ENV.fetch('DATABASE_PASSWORD') { 'password' } %>
 
-development:
-  primary:
-    <<: *database_config
-    database: dogfeeds_development
-  replica:
-    <<: *database_config
-    database: dogfeeds_development
-    replica: true
-
 test:
-  primary:
-    <<: *database_config
-    database: dogfeeds_test
-  replica:
-    <<: *database_config
-    database: dogfeeds_test
-    replica: true
+  <<: *default
+  database: dogfeeds_test
+  host: <%= ENV.fetch('DATABASE_HOST') { 'localhost' } %>
+  port: <%= ENV.fetch('DATABASE_PORT') { '5432' } %>
+  username: <%= ENV.fetch('DATABASE_USER') { 'postgres' } %>
+  password: <%= ENV.fetch('DATABASE_PASSWORD') { 'password' } %>
 
 production:
-  primary:
-    <<: *default
-    database: dogfeeds_production
-  replica:
-    <<: *default
-    database: dogfeeds_production
-    replica: true
+  <<: *default
+  database: dogfeeds_production


### PR DESCRIPTION
heroku上でposgresqlの接続できなくなったのでrevert

```
2020-08-04T01:59:46.932903+00:00 app[web.1]: [aeea4f95-eef7-4d8e-b6d1-ed710477fe09] PG::ConnectionBad (could not connect to server: No such file or directory
2020-08-04T01:59:46.932904+00:00 app[web.1]: Is the server running locally and accepting
2020-08-04T01:59:46.932904+00:00 app[web.1]: connections on Unix domain socket "/var/run/postgresql/.s.PGSQL.5432"?
```

Reverts Madogiwa0124/dogfeeds#362