### PR TITLE
:gear: 本番環境ではhttps接続を必須にした

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -12,6 +12,7 @@ Rails.application.configure do
   config.i18n.fallbacks = true
   config.active_support.deprecation = :notify
   config.log_formatter = ::Logger::Formatter.new
+  config.force_ssl = true
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
     logger           = ActiveSupport::Logger.new(STDOUT)


### PR DESCRIPTION
> config.force_ssl: ActionDispatch::SSLミドルウェアを用いて、すべてのリクエストをHTTPSプロトコル下で実行するよう強制し、かつconfig.action_mailer.default_url_optionsを{ protocol: 'https' }に設定します。これはconfig.ssl_optionsで設定できます。詳しくはActionDispatch::SSL documentationを参照してください。
> https://railsguides.jp/configuring.html