### PR TITLE
:gear: CI環境ではログ出力を抑制し高速化を図る

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ web: &web
       PGHOST: 127.0.0.1
       DATABASE_USER: circleci
       DATABASE_PASSWORD: password
+      CI: true
 db: &db
   - image: circleci/postgres:10.13
     environment:

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,6 +45,9 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  # CI実行時にはログの出力を抑制する
+  config.log_level = ENV['CI'].present? ? :fatal : :debug
+
   # configured bullet.
   config.after_initialize do
     Bullet.enable = true


### PR DESCRIPTION
> 6. CI上でのRSpec実行時に、Railsのログを吐かないようにする
> https://medium.com/studist-dev/how-to-reduce-circleci-credits-ac81de4857d8