### PR TITLE
:gear: ci上でrailsのedgeバージョン(6.1.0.rc)でCIを回すようにした

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,14 +4,24 @@ orbs:
   ruby: circleci/ruby@1.1.1
   node: circleci/node@4.0.0
 
+web-default-enviroments: &web-default-enviroments
+  RAILS_ENV: test
+  PGHOST: 127.0.0.1
+  DATABASE_USER: circleci
+  DATABASE_PASSWORD: password
+
 web: &web
   - image: circleci/ruby:2.7.1-node-browsers
     environment:
-      RAILS_ENV: test
-      PGHOST: 127.0.0.1
-      DATABASE_USER: circleci
-      DATABASE_PASSWORD: password
-      CI: true
+      <<: *web-default-enviroments
+
+web-edge: &web-edge
+  - <<: *web
+    environment:
+      <<: *web-default-enviroments
+      BUNDLE_GEMFILE: gemfiles/rails_6_1.gemfile
+      BUNDLE_PATH_RELATIVE_TO_CWD: true
+
 db: &db
   - image: circleci/postgres:10.13
     environment:
@@ -25,6 +35,10 @@ executors:
   web-db:
     docker:
       - <<: *web
+      - <<: *db
+  web-db-edge:
+    docker:
+      - <<: *web-edge
       - <<: *db
 
 commands:
@@ -116,6 +130,7 @@ jobs:
       name: web-db
     steps:
       - attach_current
+      - run: cp Gemfile.lock gemfiles/rails_61.lock
       - install_ruby_deps
       - install_node_deps
       - rails_migration
@@ -124,6 +139,18 @@ jobs:
           name: run tests
           command: bundle exec rspec spec/
       - store_coverage_atifacts
+  ruby_test_rails_edge:
+    executor:
+      name: web-db-edge
+    steps:
+      - attach_current
+      - install_ruby_deps
+      - install_node_deps
+      - rails_migration
+      - build_webpack
+      - run:
+          name: run tests
+          command: bundle exec rspec spec/
   lighthourse:
     executor:
       name: web-db
@@ -151,6 +178,10 @@ workflows:
           requires:
             - ruby_build
       - ruby_test:
+          requires:
+            - ruby_build
+            - node_build
+      - ruby_test_rails_edge:
           requires:
             - ruby_build
             - node_build

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -1,0 +1,4 @@
+eval_gemfile File.expand_path('../Gemfile', __dir__)
+
+dependencies.delete_if { |d| d.name == 'rails' }
+gem 'rails', '6.1.0.rc1'


### PR DESCRIPTION
* BUNDLE_GEMFILEを指定して`rails 6.1.0.rc`をinstallしたgemfileを参照するように
* BUNDLE_PATH_RELATIVE_TO_CWDを指定して現在のディレクトリからinstall済みのgemを参照するように
  - これによって`vendor/bundle`配下がinstall先になりキャッシュが効くようになる

参考: https://sinsoku.hatenablog.com/entry/2020/10/31/100000

対応していないgemがありtestが落ちるので、`required`からは外した。