### PR TITLE
例外処理まわりの考慮漏れにもろもろ対応

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -61,8 +61,8 @@ class Feed < ApplicationRecord
   def parsed_object
     @parsed_object ||= client_class.new(endpoint).parsed_object
   rescue RSS::NotWellFormedError => e
-    logger.error(e)
-    Rollbar.error(e)
+    logger.warn(e)
+    Rollbar.warning(e, endpoint: endpoint)
     invalid_rss_format
     nil # NOTE: rescueされたときにerrorsが返却されてしまうのでnilを返して呼び元で判定できるようにしてる
   end

--- a/app/models/feed/rss/client.rb
+++ b/app/models/feed/rss/client.rb
@@ -11,7 +11,7 @@ module Feed::Rss
     end
 
     def parsed_object
-      @parsed_object ||= PARSERS[parsed_rss.class.name].call(parsed_rss)
+      @parsed_object ||= PARSERS[parsed_rss.class.name]&.call(parsed_rss)
     end
 
     private

--- a/lib/tasks/entries_recreate.rake
+++ b/lib/tasks/entries_recreate.rake
@@ -6,7 +6,7 @@ namespace :entries do
       ActiveRecord::Base.transaction { Feed::EntryCreater.new(feed).execute! }
     rescue => e
       Rails.logger.error(e)
-      Rollbar.error(e)
+      Rollbar.error(e, endpoint: feed.endpoint)
       next
     end
   end


### PR DESCRIPTION
* Parserが存在しないケースを考慮してnilを返すようにした
* Feed#parsed_objectのRSS::NotWellFormedErrorは一定ユーザー入力でも起こりうるのでendpointと共に警告を記録するように
* 発生したURLが分かるようにendpointと共に記録するようにした