### PR TITLE
RollbarにSourceMapを送ってエラー発生箇所を特定しやすいようにする

### DIFF
--- a/app/javascript/services/Rollbar.js
+++ b/app/javascript/services/Rollbar.js
@@ -2,14 +2,23 @@
 // https://docs.rollbar.com/docs/browser-js
 const token = process.env.ROLLBAR_POST_CLIENT_ITEM_ACCESS_TOKEN;
 const railsEnv = process.env.RAILS_ENV;
+const codeVersion = process.env.SOURCE_VERSION;
+const rollbarParamsValidation = () => !(railsEnv === "test") && token;
 
-if (token && !(railsEnv === "test")) {
+if (rollbarParamsValidation()) {
   let _rollbarConfig = {
     accessToken: token,
     captureUncaught: true,
     captureUnhandledRejections: true,
     payload: {
       environment: railsEnv,
+      client: {
+        javascript: {
+          source_map_enabled: true,
+          code_version: codeVersion,
+          guess_uncaught_frames: true,
+        },
+      },
     },
   };
 

--- a/config/webpack/plugins/rollbarSourceMapConfig.js
+++ b/config/webpack/plugins/rollbarSourceMapConfig.js
@@ -1,0 +1,12 @@
+const RollbarSourceMapPlugin = require("rollbar-sourcemap-webpack-plugin");
+
+const token = process.env.ROLLBAR_POST_SERVER_ITEM_ACCESS_TOKEN;
+const codeVersion = process.env.SOURCE_VERSION;
+const publicPath = process.env.PUBLIC_PATH + "/packs";
+
+module.exports = new RollbarSourceMapPlugin({
+  accessToken: token,
+  version: codeVersion,
+  publicPath: publicPath,
+  ignoreErrors: true,
+});

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -1,5 +1,14 @@
 process.env.NODE_ENV = process.env.NODE_ENV || "production";
 
+const RollbarSourceMapPluginConfig = require("./plugins/rollbarSourceMapConfig");
 const environment = require("./environment");
+
+environment.config.merge({
+  devtool: "hidden-source-map",
+});
+
+if (process.env.UPLOAD_SOURCEMAP === "true") {
+  environment.plugins.prepend("RollbarSourceMapPlugin", RollbarSourceMapPluginConfig);
+}
 
 module.exports = environment.toWebpackConfig();

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "moment": "^2.29.1",
     "postcss-cssnext": "^3.1.0",
     "postcss-loader": "^3.0.0",
+    "rollbar-sourcemap-webpack-plugin": "^3.0.1",
     "typescript": "^4.1.2",
     "vue": "^2.6.12",
     "vue-infinite-loading": "^2.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2614,7 +2614,7 @@ color@^3.0.0:
     color-convert "^1.9.1"
     color-string "^1.5.2"
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -4093,6 +4093,15 @@ fork-ts-checker-webpack-plugin@^5.2.1:
     schema-utils "2.7.0"
     semver "^7.3.2"
     tapable "^1.0.0"
+
+form-data@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
+  integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -5695,6 +5704,16 @@ lodash.isequal@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
 
+lodash.isfunction@^3.0.9:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
+  integrity sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -6264,6 +6283,11 @@ node-fetch@^1.0.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-forge@0.9.0:
   version "0.9.0"
@@ -8621,6 +8645,17 @@ robots-parser@^2.0.1:
   resolved "https://registry.yarnpkg.com/robots-parser/-/robots-parser-2.1.1.tgz#41b289cf44a6aa136dc62be0085adca954573ab0"
   integrity sha512-6yWEYSdhK3bAEcYY0In3wgSBK70BiQoJArzdjZKCP/35b3gKIYu5Lc0qQqsoxjoLVebVoJiKK4VWGc5+oxvWBQ==
 
+rollbar-sourcemap-webpack-plugin@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/rollbar-sourcemap-webpack-plugin/-/rollbar-sourcemap-webpack-plugin-3.0.1.tgz#4332fdef80cd7f8bf93cf0c977030f093e40459f"
+  integrity sha512-kkSO632gAjmM8jqc4Ya6YoqzjZi2t1rpThDjkdbI+GqJDn7txyg94Be66xzbRzwl69FzrhnyiHuyqql7qP9OpQ==
+  dependencies:
+    form-data "^3.0.0"
+    lodash.isfunction "^3.0.9"
+    lodash.isstring "^4.0.1"
+    node-fetch "^2.6.1"
+    verror "^1.6.1"
+
 run-async@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
@@ -9949,7 +9984,7 @@ vendors@^1.0.0:
   resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.3.tgz#a6467781abd366217c050f8202e7e50cc9eef8c0"
   integrity sha512-fOi47nsJP5Wqefa43kyWSg80qF+Q3XA6MUkgi7Hp1HQaKDQW4cQrK2D0P7mmbFtsV1N89am55Yru/nyEwRubcw==
 
-verror@1.10.0:
+verror@1.10.0, verror@^1.6.1:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
   integrity sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=


### PR DESCRIPTION
`rollbar-sourcemap-webpack-plugin`を使ってRollbarにSourceMapを送信するようにした。

https://github.com/thredup/rollbar-sourcemap-webpack-plugin

herokuへのデプロイ時に以下の環境変数`SOURCE_VERSION`を参照し、
最新のcommit hashが反映された状態でwebpackのビルド及び、
SourceMapのアップロードが行われる。

それによりSourceMapとhashと実行時のRollbar設定が同一の値になるため、
コードのひも付けが行われる想定。

https://devcenter.heroku.com/changelog-items/630

公式ドキュメント: https://docs.rollbar.com/docs/source-maps