### PR TITLE
Routesファイルをnamespaceで分割

### DIFF
--- a/app/views/layouts/admin/_sidebar.html.erb
+++ b/app/views/layouts/admin/_sidebar.html.erb
@@ -6,9 +6,11 @@
     <li>
       <%= link_to 'Boards', admin_boards_path %>
     </li>
-  <ul class="menu-list">
     <li>
       <%= link_to 'Feeds', admin_feeds_path %>
+    </li>
+    <li>
+      <%= link_to 'Sidekiq', admin_sidekiq_web_path %>
     </li>
   </ul>
 </aside>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,23 +1,12 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
-  get '/', to: 'boards#new'
+  root to: 'boards#new'
   resources :feeds, only: [:index, :show, :new, :create]
   resources :boards, only: [:show, :new, :index], constraints: { format: :html }
   get '/boards/:id', to: 'rss/boards#show', constraints: lambda { |req| req.format == :rss }
   get '/mypage', to: 'mypage#show'
 
-  namespace :api do
-    resources :feeds, only: [:index, :show]
-    resources :feed_entries, only: [:index], controller: 'feed/entries'
-    resources :entries, only: [:index]
-    resources :boards, only: [:create, :show, :index]
-    resources :tags, only: [:index]
-  end
-
-  namespace :admin do
-    resources :boards
-    resources :board_feeds
-    resources :feeds
-    require 'sidekiq/web'
-    mount Sidekiq::Web, at: '/sidekiq'
-  end
+  draw(:api)
+  draw(:admin)
 end

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Rails.application.routes.draw do
+  namespace :admin do
+    root to: 'boards#index'
+    resources :boards
+    resources :board_feeds
+    resources :feeds
+    require 'sidekiq/web'
+    mount Sidekiq::Web, at: '/sidekiq'
+  end
+end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Rails.application.routes.draw do
+  namespace :api do
+    resources :feeds, only: [:index, :show]
+    resources :feed_entries, only: [:index], controller: 'feed/entries'
+    resources :entries, only: [:index]
+    resources :boards, only: [:create, :show, :index]
+    resources :tags, only: [:index]
+  end
+end


### PR DESCRIPTION
見通しを良くするためにnamespace単位でroutesのファイルを分割した。

参考：https://tech.toreta.in/entry/2020/12/22/110006