### PR TITLE
logrageを使ってログのフォーマットをいい感じにした。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '3.0.1'
 
 gem 'rails', '~> 6.1.3'
+gem 'lograge'
 gem 'rollbar'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,11 @@ GEM
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    lograge (0.11.2)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.9.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -189,6 +194,8 @@ GEM
       psych (~> 3.1)
       rainbow (>= 2.0, < 4.0)
     regexp_parser (2.1.1)
+    request_store (1.5.0)
+      rack (>= 1.4)
     rexml (3.2.5)
     rollbar (3.1.2)
     rspec-core (3.10.1)
@@ -295,6 +302,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   listen (~> 3.5)
+  lograge
   okcomputer
   pg (>= 0.18, < 2.0)
   puma

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require Rails.root.join('lib/lograge/formatters/marked_key_value')
+
+Rails.application.configure do
+  config.lograge.enabled = true
+  config.lograge.formatter = Lograge::Formatters::MarkedKeyValue.new
+  config.lograge.custom_options = ->(event) { { time: Time.current } }
+end

--- a/lib/lograge/formatters/marked_key_value.rb
+++ b/lib/lograge/formatters/marked_key_value.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'lograge'
+
+class Lograge::Formatters::MarkedKeyValue < Lograge::Formatters::KeyValue
+  INFO_MARK = '🙂'
+  SUCCES_MARK = '😃'
+  REDIRECT_MARK = '😗'
+  CLIENT_ERROR_MARK = '🤔'
+  SERVER_ERROR_MARK = '😱'
+
+  def call(data)
+    result = super(data)
+    mark = status_to_mark(data[:status].to_i)
+    "#{mark} #{result}"
+  end
+
+  def status_to_mark(status)
+    case status
+    when 100...200 then INFO_MARK
+    when 200...300 then SUCCES_MARK
+    when 300...400 then REDIRECT_MARK
+    when 400...500 then CLIENT_ERROR_MARK
+    when 500...    then SERVER_ERROR_MARK
+    else ' '
+    end
+  end
+end

--- a/spec/lib/lograge/formatters/marked_key_value_spec.rb
+++ b/spec/lib/lograge/formatters/marked_key_value_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Lograge::Formatters::MarkedKeyValue do
+  let(:payload) do
+    {
+      custom: 'data',
+      status: 200,
+      method: 'GET',
+      path: '/',
+      controller: 'welcome',
+      action: 'index'
+    }
+  end
+
+  subject { described_class.new.call(payload) }
+
+  it "includes the 'controller' key/value" do
+    expect(subject).to include('controller=welcome')
+  end
+
+  it "includes the 'action' key/value" do
+    expect(subject).to include('action=index')
+  end
+
+  it "includes the 'mark' by status" do
+    expect(subject).to include('😃')
+  end
+end


### PR DESCRIPTION
before(サンプル)

```
Started GET "/" for 127.0.0.1 at 2012-03-10 14:28:14 +0100
Processing by HomeController#index as HTML
  Rendered text template within layouts/application (0.0ms)
  Rendered layouts/_assets.html.erb (2.0ms)
  Rendered layouts/_top.html.erb (2.6ms)
  Rendered layouts/_about.html.erb (0.3ms)
  Rendered layouts/_google_analytics.html.erb (0.4ms)
Completed 200 OK in 79ms (Views: 78.8ms | ActiveRecord: 0.0ms)
```

after

```
😃 method=GET path=/api/feeds format=html controller=Api::FeedsController action=index status=200 duration=5.92 view=0.16 db=0.33 time=2021-05-23 16:21:12 +0900
😃 method=GET path=/feeds/533 format=html controller=FeedsController action=show status=200 duration=13.04 view=9.63 db=0.00 time=2021-05-23 16:21:24 +0900
😱 method=GET path=/api/feeds/533 format=html controller=Api::FeedsController action=show status=500 error='RuntimeError: ' duration=0.44 view=0.00 db=0.00 time=2021-05-23 16:21:24 +0900
```

`Lograge::Formatters::MarkedKeyValue`を用意して
各ログの最初にstatusを表すアイコンを表示しわかりやすくしてみた。