### PR TITLE
MYPAGEのCLIPした記事が更新の度に消えるバグをFIXED

### DIFF
--- a/app/javascript/components/containers/NewBoardContainer.vue
+++ b/app/javascript/components/containers/NewBoardContainer.vue
@@ -194,8 +194,8 @@ export default Vue.extend({
       this.showServiceInfomation = false;
       localStorage.setItem(SHOW_SERVICE_INFOMATION_STRAGE_KEY, "false");
     },
-    handleOnClipEntry: function (entryId: number, clieped: boolean) {
-      clipEntry(entryId, clieped);
+    handleOnClipEntry: function (entryLink: string, clieped: boolean) {
+      clipEntry(entryLink, clieped);
     },
   },
 });

--- a/app/javascript/components/containers/ShowBoardContainer.vue
+++ b/app/javascript/components/containers/ShowBoardContainer.vue
@@ -108,8 +108,8 @@ export default Vue.extend({
     handleOnEntryTabClick() {
       this.selectedTab = Tabs.Entry;
     },
-    handleOnClipEntry: function (entryId: number, clieped: boolean) {
-      clipEntry(entryId, clieped);
+    handleOnClipEntry: function (entryLink: string, clieped: boolean) {
+      clipEntry(entryLink, clieped);
     },
   },
 });

--- a/app/javascript/components/containers/ShowFeedContainer.vue
+++ b/app/javascript/components/containers/ShowFeedContainer.vue
@@ -76,8 +76,8 @@ export default Vue.extend({
       const query = `?query[keyword]=${body}`;
       window.location.href = `${TAG_CLICK_REDIRECT_PATH}/${query}`;
     },
-    handleOnClipEntry: function (entryId: number, clieped: boolean) {
-      clipEntry(entryId, clieped);
+    handleOnClipEntry: function (entryLink: string, clieped: boolean) {
+      clipEntry(entryLink, clieped);
     },
   },
 });

--- a/app/javascript/components/containers/ShowMypageContainer.vue
+++ b/app/javascript/components/containers/ShowMypageContainer.vue
@@ -36,7 +36,7 @@ import { faPaperclip, faUser } from "@fortawesome/free-solid-svg-icons";
 library.add(faPaperclip, faUser);
 
 import { Entry } from "@js/types/types";
-import { clipEntry, getClipedEntryIds, getEntries } from "@js/services/EntryService";
+import { clipEntry, getClipedEntryLinks, getEntries } from "@js/services/EntryService";
 import EntryCardCollection from "@js/components/entry/EntryCardCollection.vue";
 
 export default defineComponent({
@@ -46,12 +46,12 @@ export default defineComponent({
   setup() {
     const state = reactive<{ clipedEntries: Entry[] }>({ clipedEntries: [] });
     onMounted(async () => {
-      const clipedEntryIds = Array.from(getClipedEntryIds());
-      if (clipedEntryIds.length < 1) return;
-      state.clipedEntries = await getEntries("", { ids: clipedEntryIds, pager: false });
+      const clipedEntryLinks = Array.from(getClipedEntryLinks());
+      if (clipedEntryLinks.length < 1) return;
+      state.clipedEntries = await getEntries("", { links: clipedEntryLinks, pager: false });
     });
-    const handleOnClipEntry = (entryId: number, clieped: boolean) => {
-      clipEntry(entryId, clieped);
+    const handleOnClipEntry = (entryLink: string, clieped: boolean) => {
+      clipEntry(entryLink, clieped);
     };
     return { state, handleOnClipEntry };
   },

--- a/app/javascript/components/containers/feed/EntryCollectionContainer.vue
+++ b/app/javascript/components/containers/feed/EntryCollectionContainer.vue
@@ -73,8 +73,8 @@ export default Vue.extend({
       this.infiniteLoading.stateChanger.reset();
       this.infiniteHandler(this.infiniteLoading.stateChanger);
     },
-    handleOnClipEntry: function (entryId: number, clieped: boolean) {
-      clipEntry(entryId, clieped);
+    handleOnClipEntry: function (entryLink: string, clieped: boolean) {
+      clipEntry(entryLink, clieped);
     },
   },
 });

--- a/app/javascript/components/containers/feed/FeedCollectionContainer.vue
+++ b/app/javascript/components/containers/feed/FeedCollectionContainer.vue
@@ -96,8 +96,8 @@ export default Vue.extend({
       this.infiniteLoading.stateChanger.reset();
       this.infiniteHandler(this.infiniteLoading.stateChanger);
     },
-    handleOnClipEntry: function (entryId: number, clieped: boolean) {
-      clipEntry(entryId, clieped);
+    handleOnClipEntry: function (entryLink: string, clieped: boolean) {
+      clipEntry(entryLink, clieped);
     },
   },
 });

--- a/app/javascript/components/entry/EntryCard.vue
+++ b/app/javascript/components/entry/EntryCard.vue
@@ -19,7 +19,7 @@
         </p>
         <p class="entry-footer">
           <span :title="publishedAtText">{{ fromNow }} </span>
-          <entry-clip class="clip" :entryId="entry.id" :init-cliped="cliped" @clip="handleOnClipEntry" />
+          <entry-clip class="clip" :entry-link="entry.link" :init-cliped="cliped" @clip="handleOnClipEntry" />
         </p>
       </div>
     </div>
@@ -80,8 +80,8 @@ export default defineComponent({
   setup(props: Props, context: SetupContext) {
     const publishedAtText = computed(() => moment(props.entry.publishedAt).format("YYYY/MM/DD h:mm:ss"));
     const fromNow = computed(() => moment(props.entry.publishedAt).fromNow());
-    const handleOnClipEntry = (entryId: number, cliped: boolean, event: Event) => {
-      context.emit("clipEntry", entryId, cliped, event);
+    const handleOnClipEntry = (entryLink: string, cliped: boolean, event: Event) => {
+      context.emit("clipEntry", entryLink, cliped, event);
     };
     const limitedDescription = computed(() => {
       if (props.descriptionLimit === null) return props.entry.description;

--- a/app/javascript/components/entry/EntryCardCollection.vue
+++ b/app/javascript/components/entry/EntryCardCollection.vue
@@ -56,8 +56,8 @@ export default defineComponent({
   // propsの型定義のためsetup引数に型を設定
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   setup(props: Props, context: SetupContext) {
-    const handleOnClipEntry = (entryId: number, cliped: boolean): void => {
-      context.emit("clipEntry", entryId, cliped);
+    const handleOnClipEntry = (entryLink: string, cliped: boolean): void => {
+      context.emit("clipEntry", entryLink, cliped);
     };
     return {
       props,

--- a/app/javascript/components/entry/EntryClip.vue
+++ b/app/javascript/components/entry/EntryClip.vue
@@ -16,7 +16,7 @@ library.add(faPaperclip);
 
 type Props = {
   initCliped: boolean;
-  entryId: number;
+  entryLink: string;
   title: string;
 };
 
@@ -27,9 +27,9 @@ export default defineComponent({
       default: false,
       type: Boolean,
     },
-    entryId: {
+    entryLink: {
       required: true,
-      type: Number,
+      type: String,
     },
     title: {
       default: "Clipして後で読む",
@@ -40,7 +40,7 @@ export default defineComponent({
     const state = reactive<{ cliped: boolean }>({ cliped: props.initCliped });
     const clip = (event: Event) => {
       state.cliped = !state.cliped;
-      context.emit("clip", props.entryId, state.cliped, event);
+      context.emit("clip", props.entryLink, state.cliped, event);
     };
     return { clip, state, props };
   },

--- a/app/javascript/components/feed/FeedCard.vue
+++ b/app/javascript/components/feed/FeedCard.vue
@@ -32,7 +32,7 @@
           <p class="entry-info has-text-right">
             <span :title="lastPublishedAtText">Last updated {{ feed.lastEntry.publishedAt | fromNow }}</span>
             <font-awesome-icon :icon="['far', 'clock']" />
-            <entry-clip class="clip" :entryId="feed.lastEntry.id" @clip="handleOnClipEntry" />
+            <entry-clip class="clip" :entry-link="feed.lastEntry.link" @clip="handleOnClipEntry" />
           </p>
         </div>
       </div>
@@ -118,10 +118,10 @@ export default Vue.extend({
       event.preventDefault();
       this.$emit("clickTag", tagBody);
     },
-    handleOnClipEntry: function (entryId: number, cliped: boolean, event: Event): void {
+    handleOnClipEntry: function (entryLink: string, cliped: boolean, event: Event): void {
       event.stopPropagation();
       event.preventDefault();
-      this.$emit("clipEntry", entryId, cliped);
+      this.$emit("clipEntry", entryLink, cliped);
     },
     handleOnSelected: function (): void {
       this.$emit("selectedFeed", this.feed.id);

--- a/app/javascript/components/feed/FeedCardCollection.vue
+++ b/app/javascript/components/feed/FeedCardCollection.vue
@@ -73,8 +73,8 @@ export default Vue.extend({
     handleOnUnselected: function (id: number) {
       this.$emit("unselectedFeed", id);
     },
-    handleOnClipEntry: function (entryId: number, cliped: boolean): void {
-      this.$emit("clipEntry", entryId, cliped);
+    handleOnClipEntry: function (entryLink: string, cliped: boolean): void {
+      this.$emit("clipEntry", entryLink, cliped);
     },
   },
 });

--- a/app/javascript/components/feed/FeedInfomation.vue
+++ b/app/javascript/components/feed/FeedInfomation.vue
@@ -43,8 +43,8 @@ export default Vue.extend({
     handleOnTagClick: function (body: string) {
       this.$emit("tagClick", body);
     },
-    handleOnClipEntry: function (entryId: number, cliped: boolean): void {
-      this.$emit("clipEntry", entryId, cliped);
+    handleOnClipEntry: function (entryLink: string, cliped: boolean): void {
+      this.$emit("clipEntry", entryLink, cliped);
     },
   },
 });

--- a/app/javascript/services/EntryService.ts
+++ b/app/javascript/services/EntryService.ts
@@ -16,16 +16,16 @@ export async function getEntries(query = "", params: object): Promise<Entry[]> {
 
 const CLIP_STRAGE_KEY = "clipedEntriyIds";
 
-export function getClipedEntryIds(): Set<number> {
+export function getClipedEntryLinks(): Set<string> {
   const strage = window.localStorage;
   let strageValue = strage.getItem(CLIP_STRAGE_KEY);
   if (strageValue === null) strageValue = "[]";
-  return new Set(JSON.parse(strageValue) as number[]);
+  return new Set(JSON.parse(strageValue) as string[]);
 }
 
-export function clipEntry(entryId: number, cliped: boolean): void {
+export function clipEntry(link: string, cliped: boolean): void {
   const strage = window.localStorage;
-  const clipedEntriyIds = getClipedEntryIds();
-  cliped ? clipedEntriyIds.add(entryId) : clipedEntriyIds.delete(entryId);
+  const clipedEntriyIds = getClipedEntryLinks();
+  cliped ? clipedEntriyIds.add(link) : clipedEntriyIds.delete(link);
   strage.setItem(CLIP_STRAGE_KEY, JSON.stringify(Array.from(clipedEntriyIds)));
 }

--- a/app/models/entry/search.rb
+++ b/app/models/entry/search.rb
@@ -16,16 +16,21 @@ class Entry::Search
 
   def call
     @entries = Entry.recent
-    filters.inject(@entries) { |entries, filter| filter.call(entries) }
+    [filter_by_ids, filter_by_links, filter_by_pager].inject(@entries) { |entries, filter| filter.call(entries) }
   end
 
   private
 
-  def filters
-    [
-      ->(entries) { params[:ids] ? entries.where(id: params[:ids]) : entries },
-      ->(entries) { pager_enabled ? entries.pager(page: params[:page], per: per_page) : entries }
-    ]
+  def filter_by_ids
+    ->(entries) { params[:ids] ? entries.where(id: params[:ids]) : entries }
+  end
+
+  def filter_by_links
+    ->(entries) { params[:links] ? entries.where(link: params[:links]) : entries }
+  end
+
+  def filter_by_pager
+    ->(entries) { pager_enabled ? entries.pager(page: params[:page], per: per_page) : entries }
   end
 
   attr_reader :params, :entries, :pager_enabled, :per_page


### PR DESCRIPTION
Feedに紐づく記事はDELETE/INSERTで更新しており、
更新の度にIDは変わるため記事のURLでCLIP済の記事を取得するようにした。